### PR TITLE
Link speaker GitHub as the whole URL

### DIFF
--- a/pyconcz/templates/default/admin/proposals/add_score.html
+++ b/pyconcz/templates/default/admin/proposals/add_score.html
@@ -32,7 +32,7 @@
         <dl>
             <dt><h2>Author</h2></dt>
             <dd><strong>{{ form.full_name.value }}</strong>&nbsp; <a href="mailto:{{ form.email.value }}">{{ form.email.value }}</a>
-                {% if form.github.value %}gh: <a href="https://www.github.com/{{ form.github.value }}" target="_blank"> {{ form.github.value }}</a> {% endif %}
+                {% if form.github.value %}gh: <a href="{{ form.github.value }}" target="_blank"> {{ form.github.value }}</a> {% endif %}
                 {% if form.twitter.value %}tw: <a href="https://www.twitter.com/{{ form.twitter.value }}" target="_blank">{{ form.twitter.value }}</a> {% endif %}
                 photo: <a href="{{ MEDIA_URL }}{{ form.photo.value }}" target="_blank">show</a>
                 {% if form.referral_link.value %}video/link: <a href="{{ form.referral_link.value }}" target="_blank">show</a> {% endif %}

--- a/pyconcz/templates/default/pages/homepage.html
+++ b/pyconcz/templates/default/pages/homepage.html
@@ -159,7 +159,7 @@
                                         <span class="col">TW:&nbsp;<a href="http://twitter.com/{{ keynoter.twitter }}">@{{ keynoter.twitter }}</a></span>
                                     {% endif %}
                                     {% if keynoter.github %}
-                                        <span class="col">GH:&nbsp;<a href="https://github.com/{{ keynoter.github }}">{{ keynoter.github }}</a></span>
+                                        <span class="col">GH:&nbsp;<a href="{{ keynoter.github }}">{{ keynoter.github }}</a></span>
                                     {% endif %}
                                 </p>
                             {% endif %}

--- a/pyconcz/templates/default/programme/_base_detail.html
+++ b/pyconcz/templates/default/programme/_base_detail.html
@@ -147,7 +147,7 @@
                         {% if speaker.github %}
                             <div class="col">
                                 GH:
-                                <a href="https://github.com/{{ speaker.github }}">
+                                <a href="{{ speaker.github }}">
                                     {{ speaker.github }}
                                 </a>
                             </div>


### PR DESCRIPTION
The form question for `github` says “Your public code repository (GitHub, GitLab, …)”, so that's what people submitted.
We should not prepend `https://www.github.com/` to the full URL.
