### PR TITLE
Financial aid end date is in CEST

### DIFF
--- a/pyconcz/templates/default/proposals/financial_aid_about.html
+++ b/pyconcz/templates/default/proposals/financial_aid_about.html
@@ -25,7 +25,7 @@
 
         <p>
             Financial aid applications open on {{ proposal_config.date_start | date:'j F' }} and
-            <b>close on {{ proposal_config.date_end | date:'j F' }}, 23:59 CET</b>.
+            <b>close on {{ proposal_config.date_end | date:'j F' }}, 23:59 CEST</b>.
             After that we will carefully examine each application and inform all applicants privately before the end of {{ proposal_config.date_end | date:'F' }} about the result.
         </p>
 


### PR DESCRIPTION
This change doesn't scale, but works for the actual end date we have.