### PR TITLE
Plumbing for talk/workshop lists

### DIFF
--- a/pyconcz/programme/models.py
+++ b/pyconcz/programme/models.py
@@ -51,6 +51,7 @@ class Talk(models.Model):
         ('en', 'English (preferred)'),
         ('cs', 'Czechoslovak'),
     )
+    type = 'talk'  # for symmetry with workshops/sprints
 
     title = models.CharField(max_length=200)
     abstract = models.TextField()

--- a/pyconcz/programme/urls.py
+++ b/pyconcz/programme/urls.py
@@ -1,12 +1,14 @@
 from django.conf.urls import url
 from django.views.generic import RedirectView
 
-from .views import speakers_list, schedule, talk_detail, preview
+from .views import talk_list, workshop_list, schedule
+from .views import talk_detail, preview
 
 urlpatterns = [
-    url('^$', RedirectView.as_view(pattern_name='speakers_list'), {'type': 'talks'}),
-    url('^(?P<type>(talks|workshops))/$', speakers_list, name="speakers_list"),
-    url('^detail/(?P<type>(talk|workshop))/(?P<talk_id>\d+)/$', talk_detail, name='talk_detail'),
+    url('^$', RedirectView.as_view(pattern_name='talk_list')),
+    url('^talks/$', talk_list, name="talk_list"),
+    url('^workshops/$', workshop_list, name="workshop_list"),
+    url('^detail/(?P<type>(talk|workshop|sprint))/(?P<talk_id>\d+)/$', talk_detail, name='talk_detail'),
     url('^schedule/$', schedule, name="programme_schedule"),
     url('^preview/$', preview, name="preview"),
 ]

--- a/pyconcz/programme/views.py
+++ b/pyconcz/programme/views.py
@@ -18,6 +18,30 @@ def preview(request):
     )
 
 
+def talk_list(request):
+    talks = (Talk.objects.filter(is_public=True)
+        .filter(is_public=True, is_backup=False)
+        .order_by('title'))
+
+    return TemplateResponse(
+        request,
+        template='programme/session_list.html',
+        context={'sessions': talks, 'list_title':'Talks'}
+    )
+
+
+def workshop_list(request):
+    workshops = (Workshop.objects.filter(is_public=True)
+        .filter(is_public=True, is_backup=False)
+        .order_by('title'))
+
+    return TemplateResponse(
+        request,
+        template='programme/session_list.html',
+        context={'sessions': workshops, 'list_title':'Workshops'}
+    )
+
+
 def speakers_list(request, type):
     speakers = (Speaker.objects.filter(is_public=True).filter(
         **{type+'__is_public': True, type+'__is_backup': False})
@@ -33,7 +57,7 @@ def speakers_list(request, type):
 
 
 def talk_detail(request, type, talk_id):
-    MODEL_MAP = dict(talk=Talk, workshop=Workshop)
+    MODEL_MAP = dict(talk=Talk, workshop=Workshop, sprint=Workshop)
     obj = get_object_or_404(MODEL_MAP.get(type), id=talk_id, is_public=True)
 
     return TemplateResponse(

--- a/pyconcz/templates/programme/session_list.html
+++ b/pyconcz/templates/programme/session_list.html
@@ -1,0 +1,48 @@
+{% extends '_layout.html' %}
+
+
+{% load formatting %}
+
+
+{% block meta_title %}{{ list_title }}{% endblock %}
+
+
+{% block main %}
+    <div class="container-fluid">
+
+        <nav role="navigation" class="d-none d-md-block">
+            {% include '_menu_programme.html' %}
+        </nav>
+
+        <h1>{% block list_title %}{{ list_title }}{% endblock %}</h1>
+
+        {% block top_info %}{% endblock %}
+
+        <div>
+            {% for session in sessions %}
+                {% block session %}
+                    <div>
+                        <a class="d-block h-100" {% if session.title != 'TBD' %}href="{% url 'talk_detail' type=session.type talk_id=session.id %}"{% endif %}>
+                            <h2>{{ session.title }}</h2>
+                        </a>
+
+                        {% for speaker in session.speakers %}
+                        <div style="background-image: url({{ speaker.photo.url }})"></div>
+
+                        <h2>{{ speaker.full_name }}</h2>
+                        {% endfor %}
+
+                            <div>
+                                {% if session.title == 'TBD' %}
+                                    This {{ session.type }} will be announced later
+                                {% else %}
+                                    {{ session.title|markdown|cut:'<p>'|cut:'</p>' }}
+                                {% endif %}
+                            </div>
+                        </a>
+                    </div>
+                {% endblock %}
+            {% endfor %}
+        </div>
+    </div>
+{% endblock %}

--- a/pyconcz/templates/programme/sprint_detail.html
+++ b/pyconcz/templates/programme/sprint_detail.html
@@ -1,0 +1,1 @@
+{% extends 'programme/workshop_detail.html' %}


### PR DESCRIPTION
* Use a new `session_list` template instead of `speaker_list`. It gets either talks or workshops+sprints.
* Talks now have `type='talk'`, to complement workshops that have `type='workshop'` or `type='sprint`
* Added a new template, `sprint_detail`. Use it if you wish.

Or do you want one combined list with both talks and workshops?
What should these be sorted by?
