### PR TITLE
Added view which reuses the session detail template and adds correct linkage

### DIFF
--- a/pyconcz/programme/urls.py
+++ b/pyconcz/programme/urls.py
@@ -2,11 +2,12 @@ from django.conf.urls import url
 from django.views.generic import RedirectView
 
 from .views import talks_list, workshops_list, schedule, workshops_refresh_tickets
-from .views import session_detail, preview
+from .views import session_detail, preview, session_detail_schedule
 
 urlpatterns = [
     url('^$', RedirectView.as_view(pattern_name='talks_list')),
     url('^(?P<type>(talk|workshop|sprint))s/(?P<session_id>\\d+)/$', session_detail, name='session_detail'),
+    url('^(?P<type>(talk|workshop|sprint))s/(?P<slot_id>\\d+)/schedule/$', session_detail_schedule, name='session_detail_schedule'),
     url('^talks/$', talks_list, name='talks_list'),
     url('^workshops/$', workshops_list, name='workshops_list'),
     url('^workshops/refresh_tickets$', workshops_refresh_tickets, name='workshops_refresh_tickets'),

--- a/pyconcz/templates/programme/_base_detail.html
+++ b/pyconcz/templates/programme/_base_detail.html
@@ -129,12 +129,21 @@
 
     <div class="pc-sticky-bottom pc-mw-max mx-auto">
         <div class="pr-2 px-sm-3 pb-2 mb-2 d-flex justify-content-between">
-            <a class="btn btn-secondary px-2 px-sm-3" href="{% url 'session_detail' type=session_previous.type session_id=session_previous.id %}#main">
+            {% if session_previous %}
+            <a class="btn btn-secondary px-2 px-sm-3" href="{% if 'schedule' in request.path %}{% url 'session_detail_schedule' type=session_previous.content_object.type slot_id=session_previous.id  %}{% else %}{% url 'session_detail' type=session_previous.type session_id=session_previous.id %}{% endif %}#main">
                 previous {{ session_previous.type }}
             </a>
-            <a class="btn btn-info px-2 px-sm-3" href="{% url 'session_detail' type=session_next.type session_id=session_next.id %}#main">
+            {% endif %}
+            {% if session_next_room and 'schedule' in request.path %}
+            <a class="btn btn-info px-2 px-sm-3" href="{% url 'session_detail_schedule' type=session_next_room.content_object.type slot_id=session_next_room.id  %}#main">
+                Parallel Track: {{ session_next_room.content_object.title }}
+            </a>
+            {% endif %}
+            {% if session_next %}
+            <a class="btn btn-info px-2 px-sm-3" href="{% if 'schedule' in request.path %}{%  url 'session_detail_schedule' type=session_next.content_object.type slot_id=session_next.id  %}{% else %}{% url 'session_detail' type=session_next.type session_id=session_next.id %}{% endif %}#main">
                 next {{ session_next.type }}
             </a>
+            {% endif %}
         </div>
     </div>
 

--- a/pyconcz/templates/programme/slot_schedule.html
+++ b/pyconcz/templates/programme/slot_schedule.html
@@ -93,6 +93,123 @@
                                 {{ slot.room_name }}
                             </p>
                         {% endif %}
+                                <div class="{% comment %}{% endcomment %}
+                                    {% if day.grouper == 'Sunday, 3 June' %}
+                                        {% if slot.grouper|time == '10:00' or slot.grouper|time == '14:00' %}
+                                            col-sm-6
+                                        {% else %}
+                                            col-sm-12
+                                        {% endif %}
+                                    {% else %}
+                                        col-12
+                                    {% endif %}
+                               ">
+
+                                    {% if day.grouper != 'Sunday, 3 June' or slot.grouper|time != '11:00' %}
+                                        <h3>
+                                            {{ slot.grouper|time }}
+                                        </h3>
+                                    {% endif %}
+
+                                    {% if slot.list.0.description|truncatewords_html:1 == 'Welcome ...' or slot.list.0.description == 'Lightning Talks' or slot.list.0.description == 'Closing ceremony' %}
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 col-sm-6">
+                                                <h4 class="h5">Main</h4>
+                                                <p class="h5 -serif">{{ slot.list.0.description|safe }}</p>
+                                            </div>
+                                        </div>
+                                    {% elif slot.list.0.description %}
+                                        <p class="h5
+                                            {% if slot.list.0.description|truncatewords_html:1 == 'Afterparty ...' %}
+                                                {% elif slot.list.0.description == 'board_game_night' %}
+                                                {% else %}
+
+                                            {% endif %}
+                                       ">
+                                            {% if slot.list.0.description == 'board_game_night' %}
+                                                <a href="{% url 'board_game_night' %}">Board Game Night!</a>
+                                            {% else %}
+                                                {{ slot.list.0.description|safe }}
+                                            {% endif %}
+                                        </p>
+                                    {% endif %}
+
+                                    <div class="row justify-content-center">
+                                        {% for slot_item in slot.list %}
+                                            {% if slot_item.content_type and slot_item.room != 20 %}
+
+                                                <div class="col-12 {% if day.grouper != 'Sunday, 3 June' %} {% if slot.grouper|time != '10:00' and slot.grouper|time != '14:00' %} col-sm-6 {% endif %} {% endif %}">
+                                                    {% if slot_item.content_type.model != 'utility'%}
+                                                    <h4
+                                                        class="
+                                                            h5
+                                                            {% if slot_item.room == 1 %}
+
+                                                            {% elif slot_item.room == 2 %}
+
+                                                            {% elif slot_item.room == 20 %}
+
+                                                            {% elif slot_item.room < 20 %}
+
+                                                            {% elif slot_item.room == 50 %}
+
+                                                            {% else %}
+
+                                                            {% endif %}
+                                                        "
+                                                    >
+                                                        {% for key, value in ALL_ROOMS %}
+                                                            {% if slot_item.room == key %} {{ value }} {% endif %}
+                                                        {% endfor %}
+                                                    </h4>
+                                                    {% endif %}
+
+                                                    <div class="h5">
+                                                        {% if slot_item.content_type.model == 'talk' %}
+                                                            <a
+                                                                class="d-block -serif {% if slot_item.room == 1 %} {% elif slot_item.room == 2 %} {% elif slot_item.room < 20 %} {% elif slot_item.room == 20 %} {% elif slot_item.room == 50 %} {% else %} {% endif %}"
+                                                                href="{% url 'session_detail_schedule' type='talk' slot_id=slot_item.id %}"
+                                                            >
+                                                                {{ slot_item.content_object.title|markdown|cut:'<p>'|cut:'</p>' }}
+                                                            </a>
+                                                            {% comment %}<span>{{ slot_item.content_object.talks.all|join:'<br>' }}</span>{% endcomment %}
+                                                        {% elif slot_item.content_type.model == 'workshop' %}
+                                                            <a
+                                                                class="d-block -serif {% if slot_item.room == 1 %} {% elif slot_item.room == 2 %} {% elif slot_item.room < 20 %} {% elif slot_item.room == 20 %} {% elif slot_item.room == 50 %} {% else %} {% endif %}"
+                                                                href="{% url 'session_detail_schedule' type='workshop' slot_id=slot_item.id %}"
+                                                            >
+                                                                {{ slot_item.content_object.title|markdown|cut:'<p>'|cut:'</p>' }}
+                                                            </a>
+                                                            {% comment %}<span>{{ slot_item.content_object.workshops.all|join:'<br>' }}</span>{% endcomment %}
+                                                        {% elif slot_item.description == 'Sprints' %}
+                                                            <div>{{ slot_item.description }}</div>
+                                                            <div>freely accesible for anybody wearing a&nbsp;PyCon&nbsp;CZ badge</div>
+                                                        {% elif slot_item.content_type.model == 'utility'%}
+                                                            {% if slot_item.content_object.url %}
+                                                            <a
+                                                                class="d-block -serif"
+                                                                href="{% if 'http' in slot_item.content_object.url %} {{ slot_item.content_object.url }} {% else %} {{ domain}}{{ slot_item.content_object.url }} {% endif %}"
+                                                            >
+                                                                {{ slot_item.content_object.title|markdown|cut:'<p>'|cut:'</p>' }}
+                                                            </a>
+                                                            {% else %}
+                                                                {{ slot_item.content_object.title|markdown|cut:'<p>'|cut:'</p>' }}
+                                                            {% endif %}
+                                                            {% if slot_item.content_object.description %}
+                                                                {{ slot_item.content_object.description }}
+                                                            {% endif%}
+                                                        {% endif %}
+                                                        <span class="d-block">{{ slot_item.content_object.speakers|join:' &amp; ' }}</span>
+                                                    </div>
+
+                                                    {% if slot_item.content_object.difficulty == 'advanced' %}
+                                                        <p class="small">This {{ slot_item.content_type.model }} is aimed at advanced Pythonistas.</p>
+                                                    {% endif %}
+                                                    {% if slot_item.content_object.language == 'cs' %}
+                                                        <p class="small">This talk will be in Czech only.</p>
+                                                    {% endif %}
+
+                                                    {% comment %}<p>{{ slot_item.content_object.abstract|markdown }}</p>{% endcomment %}
 
                         <h3 class="mt-0 mb-2
                             {% if slot.content_object.url or slot.content_type.model == 'talk' or slot.content_type.model == 'workshop' %}


### PR DESCRIPTION
We needed a way to display correct linkage, on session detail, when someone
clicked on an item from the schedule. Also fixed several remainers of the
field date which was removed in the commit 852b08ebaae.

Ticket-ID: #128

Signed-off-by: Martin Curlej <mcurlej@redhat.com>