### PR TITLE
[WIP] docker compose for frontend devs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu
+
+RUN apt-get update
+RUN apt-get -y install curl dirmngr apt-transport-https lsb-release ca-certificates
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs python3 python3-pip python3-psycopg2 python3-pillow python3-tablib
+
+WORKDIR /app
+COPY requirements.txt /app
+COPY requirements-dev.txt /app
+
+RUN pip3 install -r requirements-dev.txt
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+    - "8000:8000"
+    links:
+    - redis
+    - db
+    depends_on:
+    - db
+    - redis
+    environment:
+      DEBUG: 1
+      DB_HOST: db
+      DB_USER: postgres
+      DB_PASS: password
+    command: bash -c "python3 manage.py migrate && npm install && npm start"
+    volumes:
+      - ./:/app
+  redis:
+    image: redis
+  db:
+    image: postgres:12
+    volumes:
+    - dbdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
+volumes:
+  dbdata: {}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,8 +19,8 @@ const rename = require('gulp-rename');
 gulp.task('runserver', gulp.series(
     function runDjangoDevServer(done){
         const djangoDevServer = spawn(
-            'env/bin/python',
-            ['manage.py', 'runserver', '--settings=pyconcz.settings.local']
+            'python3',
+            ['manage.py', 'runserver', '0:8000']
         );
 
         djangoDevServer.stdout.on('data', data => {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ django~=1.11.7
 django-redis~=4.10.0
 raven~=6.3.0
 #apt install libpq-dev
-psycopg2~=2.7.3
+psycopg2
 markdown~=2.6.8
 #apt install libtiff4-dev libjpeg8-dev zlib1g-dev libfreetype6-dev
-pillow~=3.4.1
+pillow
 pyt==0.7.26
 django-import-export~=0.5.1
 django-widget-tweaks~=1.4.1


### PR DESCRIPTION
Experimental docker setup that should enable frontend devs to get back work without any dependency beyond docker. The idea is that simply running `docker-compose up` will bring up the dev server already configured without having to worry about `node` or `python` environments or having `PostgreSQL` and `redis` running.

Outstanding issues:

- [x] `npm start` just doesn't work for me and I don't know why
- [ ] had to relax some dependencies for now to get it running on `ubuntu`
