### PR TITLE
Remove links to instagram from 2023 pages

### DIFF
--- a/2023/cfp-guide.html
+++ b/2023/cfp-guide.html
@@ -100,7 +100,6 @@
         <p>
             <a href="https://twitter.com/pyconcz">Twitter</a>
             <a href="https://www.facebook.com/events/1009813049380535/">Facebook</a>
-            <a href="https://www.instagram.com/pyconcz/">Instagram</a>
             <a href="https://github.com/pyvec/cz.pycon.org-2019">GitHub</a>
             <a href="https://www.youtube.com/channel/UCRC2Vu7p4SJxhhuRdl8rQ6g">YouTube</a>
         </p>

--- a/2023/cfp-pruvodce.html
+++ b/2023/cfp-pruvodce.html
@@ -110,7 +110,6 @@
         <p>
             <a href="https://twitter.com/pyconcz">Twitter</a>
             <a href="https://www.facebook.com/events/1009813049380535/">Facebook</a>
-            <a href="https://www.instagram.com/pyconcz/">Instagram</a>
             <a href="https://github.com/pyvec/cz.pycon.org-2019">GitHub</a>
             <a href="https://www.youtube.com/channel/UCRC2Vu7p4SJxhhuRdl8rQ6g">YouTube</a>
         </p>

--- a/2023/cfp.html
+++ b/2023/cfp.html
@@ -244,7 +244,6 @@
         <p>
             <a href="https://twitter.com/pyconcz">Twitter</a>
             <a href="https://www.facebook.com/events/1009813049380535/">Facebook</a>
-            <a href="https://www.instagram.com/pyconcz/">Instagram</a>
             <a href="https://github.com/pyvec/cz.pycon.org-2019">GitHub</a>
             <a href="https://www.youtube.com/channel/UCRC2Vu7p4SJxhhuRdl8rQ6g">YouTube</a>
         </p>

--- a/2023/coc.html
+++ b/2023/coc.html
@@ -139,7 +139,6 @@
         <p>
             <a href="https://twitter.com/pyconcz">Twitter</a>
             <a href="https://www.facebook.com/events/1009813049380535/">Facebook</a>
-            <a href="https://www.instagram.com/pyconcz/">Instagram</a>
             <a href="https://github.com/pyvec/cz.pycon.org-2019">GitHub</a>
             <a href="https://www.youtube.com/channel/UCRC2Vu7p4SJxhhuRdl8rQ6g">YouTube</a>
         </p>

--- a/2023/index.html
+++ b/2023/index.html
@@ -90,7 +90,6 @@
         <p>
             <a href="https://twitter.com/pyconcz">Twitter</a>
             <a href="https://www.facebook.com/events/1009813049380535/">Facebook</a>
-            <a href="https://www.instagram.com/pyconcz/">Instagram</a>
             <a href="https://github.com/pyvec/cz.pycon.org-2019">GitHub</a>
             <a href="https://www.youtube.com/channel/UCRC2Vu7p4SJxhhuRdl8rQ6g">YouTube</a>
         </p>

--- a/2023/privacy-policy.html
+++ b/2023/privacy-policy.html
@@ -154,7 +154,6 @@
         <p>
             <a href="https://twitter.com/pyconcz">Twitter</a>
             <a href="https://www.facebook.com/events/1009813049380535/">Facebook</a>
-            <a href="https://www.instagram.com/pyconcz/">Instagram</a>
             <a href="https://github.com/pyvec/cz.pycon.org-2019">GitHub</a>
             <a href="https://www.youtube.com/channel/UCRC2Vu7p4SJxhhuRdl8rQ6g">YouTube</a>
         </p>


### PR DESCRIPTION
Because we're removing the Instagram account, I removed links from 2023 content.

Q: Is Mia not in this repo yet?